### PR TITLE
Avoid modifying attribute lists in-place

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -3,6 +3,7 @@ package protoslog
 import (
 	"context"
 	"log/slog"
+	"slices"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -72,8 +73,12 @@ func (h Handler) wrapAttrs(attrs []slog.Attr) {
 func (h Handler) wrapAttr(attr slog.Attr) slog.Attr {
 	switch attr.Value.Kind() {
 	case slog.KindGroup:
-		h.wrapAttrs(attr.Value.Group())
-		return attr
+		attrs := slices.Clone(attr.Value.Group())
+		h.wrapAttrs(attrs)
+		return slog.Attr{
+			Key:   attr.Key,
+			Value: slog.GroupValue(attrs...),
+		}
 	case slog.KindAny, slog.KindLogValuer:
 		switch msg := attr.Value.Any().(type) {
 		case proto.Message:


### PR DESCRIPTION
Since we're not deep-cloning the attributes, there is a risk of modifying the group's attrs in place, causing a data race. This avoids that by cloning the slice before wrapping.